### PR TITLE
Run unit tests with assertions enabled in all dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build Tests
         run: |
           cd tests/unit_tests
-          alr build --validation -- -XREPORT_FORMAT=junit
+          alr build --profiles=*=validation -- -XREPORT_FORMAT=junit
 
       - name: Run Tests
         run: |


### PR DESCRIPTION
This enables all run-time checks in dependencies (except those that are explicitly disabled via pragma Assertion_Policy) which gives the best chance of catching errors during unit tests.