### PR TITLE
Corrections to handling Element_Type in contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ declare
 
    package BTrees is new Stree.Unbounded_Multiway_Trees
      (Element_Type => Integer,
-      Way_Type     => Way_Type);
+      Way_Type     => Way_Type,
+      "="          => "=");
 
    Container : BTrees.Tree;
    Node_2    : BTrees.Cursor;

--- a/src/stree-functional-multiway_trees.ads
+++ b/src/stree-functional-multiway_trees.ads
@@ -634,7 +634,9 @@ is
      Post   =>
        Length (Add_Parent'Result) = Length (Container) + 1
        and then Contains (Add_Parent'Result, Node)
-       and then Element_Logic_Equal (New_Item, Get (Add_Parent'Result, Node))
+       and then Element_Logic_Equal
+                  (Copy_Element (New_Item),
+                   Get (Add_Parent'Result, Node))
        and then Subtree_Elements_Shifted
                   (Left         => Container,
                    Right        => Add_Parent'Result,

--- a/tests/proof_tests/tests/simple_delete/p.ads
+++ b/tests/proof_tests/tests/simple_delete/p.ads
@@ -8,7 +8,8 @@ is
 
    package P_Trees is new Stree.Unbounded_Multiway_Trees
      (Element_Type => Integer,
-      Way_Type     => Way_Type);
+      Way_Type     => Way_Type,
+      "="          => "=");
    use P_Trees;
 
    procedure Create (T : out Tree);

--- a/tests/proof_tests/tests/simple_insert_child_sequence/p.ads
+++ b/tests/proof_tests/tests/simple_insert_child_sequence/p.ads
@@ -8,7 +8,8 @@ is
 
    package P_Trees is new Stree.Unbounded_Multiway_Trees
      (Element_Type => Integer,
-      Way_Type     => Way_Type);
+      Way_Type     => Way_Type,
+      "="          => "=");
    use P_Trees;
 
    procedure Create (T : out Tree);

--- a/tests/proof_tests/tests/simple_insert_parent_sequence/p.ads
+++ b/tests/proof_tests/tests/simple_insert_parent_sequence/p.ads
@@ -8,7 +8,8 @@ is
 
    package P_Trees is new Stree.Unbounded_Multiway_Trees
      (Element_Type => Integer,
-      Way_Type     => Way_Type);
+      Way_Type     => Way_Type,
+      "="          => "=");
    use P_Trees;
 
    procedure Create (T : out Tree);

--- a/tests/unit_tests/src/tree_tests.ads
+++ b/tests/unit_tests/src/tree_tests.ads
@@ -14,6 +14,7 @@ package Tree_Tests is
 
    package Integer_3Way_Trees is new Stree.Unbounded_Multiway_Trees
      (Element_Type => Integer,
-      Way_Type     => Direction);
+      Way_Type     => Direction,
+      "="          => "=");
 
 end Tree_Tests;


### PR DESCRIPTION
In the functional trees, Element_Logic_Equal is used to compare elements and Copy_Element must be used when comparing an element parameter to ensure correct rejection of access types.

In Unbounded_Multiway_Trees, Equivalent_Elements is removed and replaced with operator "=" to ensure equality is always checked correctly.

The postcondition of Constant_Reference is also fixed to use Element_Logic_Equal appropriately.