### PR TITLE
Strengthen contracts for Insert_Child, Insert_Parent, and Delete

### DIFF
--- a/src/spark-containers-formal-unbounded_multiway_trees.adb
+++ b/src/spark-containers-formal-unbounded_multiway_trees.adb
@@ -282,11 +282,11 @@ is
          return True;
       end Same_Mapping_Except_Subtree;
 
-      -----------------------------
-      -- Subtree_Mapping_Shifted --
-      -----------------------------
+      ----------------------------------
+      -- Subtree_Mapping_Shifted_Down --
+      ----------------------------------
 
-      function Subtree_Mapping_Shifted
+      function Subtree_Mapping_Shifted_Down
         (Left, Right  : Tree;
          Subtree_Root : M.Path_Type;
          Way          : Way_Type) return Boolean
@@ -296,6 +296,20 @@ is
            Right       => Right,
            Old_Subtree => Subtree_Root,
            New_Subtree => M.Child (Subtree_Root, Way)));
+
+      --------------------------------
+      -- Subtree_Mapping_Shifted_Up --
+      --------------------------------
+
+      function Subtree_Mapping_Shifted_Up
+        (Left, Right  : Tree;
+         Subtree_Root : M.Path_Type) return Boolean
+      is
+        (Subtree_Remapped
+          (Left        => Left,
+           Right       => Right,
+           Old_Subtree => Subtree_Root,
+           New_Subtree => M.Parent (Subtree_Root)));
 
       ----------------------
       -- Subtree_Remapped --
@@ -354,6 +368,43 @@ is
 
          return (L_Node = L_Last) and then (R_Node = R_Last);
       end Subtree_Remapped;
+
+      ------------------------
+      -- Elements_Preserved --
+      ------------------------
+
+      function Elements_Preserved (Left, Right : Tree) return Boolean is
+         C : Cursor;
+      begin
+         C := Root (Left);
+
+         while C /= No_Element loop
+            if not Has_Element_Impl (Right, C) then
+               return False;
+            end if;
+
+            declare
+               L : constant not null access constant Element_Type :=
+                     EHT.Element_Access
+                       (Node_Vectors.Constant_Reference
+                          (Left.Nodes, C.Node)
+                          .Element.all.Element);
+               R : constant not null access constant Element_Type :=
+                     EHT.Element_Access
+                       (Node_Vectors.Constant_Reference
+                          (Right.Nodes, C.Node)
+                          .Element.all.Element);
+            begin
+               if L.all /= R.all then
+                  return False;
+               end if;
+            end;
+
+            C := Next_Impl (Left, C);
+         end loop;
+
+         return True;
+      end Elements_Preserved;
 
       ------------------------
       -- Ancestry_Preserved --

--- a/src/spark-containers-functional-multiway_trees.adb
+++ b/src/spark-containers-functional-multiway_trees.adb
@@ -1269,6 +1269,17 @@ is
    function Nodes_Included (Left, Right : Tree) return Boolean is
      (Nodes_Included_In_Subtrees (Left, Right, Root, Root));
 
+   ---------------------------
+   -- Nodes_Included_Except --
+   ---------------------------
+
+   function Nodes_Included_Except
+     (Left          : Tree;
+      Right         : Tree;
+      Excluded_Node : Path_Type) return Boolean
+   is
+      (Nodes_Included_Except_Subtree (Left, Right, Excluded_Node));
+
    -----------------------------------
    -- Nodes_Included_Except_Subtree --
    -----------------------------------

--- a/src/spark-containers-functional-multiway_trees.ads
+++ b/src/spark-containers-functional-multiway_trees.ads
@@ -550,6 +550,21 @@ is
                               Right_Subtree => Left_Subtree)),
      Annotate => (GNATprove, Inline_For_Proof);
 
+   function Nodes_Included_Except
+     (Left          : Tree;
+      Right         : Tree;
+      Excluded_Node : Path_Type) return Boolean
+   with
+     Global => null,
+     Post   =>
+       Nodes_Included_Except'Result =
+         (for all Node of Left =>
+            (if Node /= Excluded_Node then
+               Contains (Right, Node))),
+     Annotate => (GNATprove, Inline_For_Proof);
+   --  Returns True if Left contains only nodes of Right, except for
+   --  Excluded_Node.
+
    function Nodes_Included_Except_Subtree
      (Left          : Tree;
       Right         : Tree;
@@ -617,7 +632,7 @@ is
        and then Element_Logic_Equal (Get (Add'Result, New_Node),
                                      Copy_Element (New_Item))
        and then Elements_Equal (Container, Add'Result)
-       and then Nodes_Included_Except_Subtree (Add'Result, Container, New_Node)
+       and then Nodes_Included_Except (Add'Result, Container, New_Node)
        and then Is_Leaf (Add'Result, New_Node);
 
    function Add_Parent


### PR DESCRIPTION
The contracts for Insert_Parent stated how the mapping was preserved from the old and new containers, but said nothing in the other direction. This is now corrected and a new property function Subtree_Mapping_Shifted_Up is added.

Also, the provers found it difficult to prove that the element associated with each cursor is preserved for Insert_Parent, so a new property function Elements_Preserved is added to prove this property.

The precondition for Direction is also corrected to require that the target node is not the root node, since otherwise it violates the precondition of M.Way_From_Parent in the call from Direction's postcondition.