### PR TITLE
Add precondition for Mapping_Preserved_Except_Subtree

### DIFF
--- a/src/spark-containers-formal-unbounded_multiway_trees.ads
+++ b/src/spark-containers-formal-unbounded_multiway_trees.ads
@@ -261,6 +261,7 @@ is
       with
         Ghost,
         Global => null,
+        Pre    => P.Has_Key (Paths (Left), Position),
         Post   =>
           Mapping_Preserved_Except_Subtree'Result =
              --  Right contains all the cursors of Left that are not in the


### PR DESCRIPTION
The postcondition calls `M_Path (Left, Position)` and the precondition for `M_Path requires P.Has_Key (Paths (Left), Position)`, but that is not currently guaranteed to be true. The new precondition ensures the precondition of `M_Path` is not violated.